### PR TITLE
lunarcalendar-ext 0.0.1 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,2 @@
-upload_channels:
-  - sfe1ed40
-
+channels:
+  - https://staging.continuum.io/prefect/fs/ephem-feedstock/pr6/3ba0d3a

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/prefect/fs/ephem-feedstock/pr6/3ba0d3a

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
+upload_channels:
+  - sfe1ed40
+
 channels:
   - https://staging.continuum.io/prefect/fs/ephem-feedstock/pr6/3ba0d3a

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-add-version-var.patch
 
 build:
-  skip: True  # [py==312 or s390x or (py>39 and arm64)]
+  skip: True  # [s390x]
   number: 0
   entry_points:
     - lunar-find=lunarcalendar.command:find
@@ -28,8 +28,7 @@ requirements:
     - python
     - wheel
   run:
-    - ephem >=3.7.5.3  # [not arm64]
-    - ephem 3.7.7  # [arm64]
+    - ephem >=3.7.5.3
     - python
     - python-dateutil >=2.6.1
     - pytz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-add-version-var.patch
 
 build:
-  skip: True  # [py==312]
+  skip: True  # [py==312 or s390x]
   number: 0
   entry_points:
     - lunar-find=lunarcalendar.command:find
@@ -28,7 +28,7 @@ requirements:
     - python
     - wheel
   run:
-    - ephem >=3.7.5.3
+    - ephem >=3.7.5.3,<4.1.*
     - python
     - python-dateutil >=2.6.1
     - pytz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,8 @@ build:
 
 requirements:
   build:
-    - patch
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - wheel
   run:
     - ephem >=3.7.5.3  # [not arm64]
-    - ephem >=3.7.5.3,<4.*  # [arm64]
+    - ephem 3.7.7  # [arm64]
     - python
     - python-dateutil >=2.6.1
     - pytz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-add-version-var.patch
 
 build:
-  skip: True  # [py==312 or s390x]
+  skip: True  # [py==312 or s390x or (py>310 and osx)]
   number: 0
   entry_points:
     - lunar-find=lunarcalendar.command:find

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,19 +13,22 @@ source:
     - 0001-add-version-var.patch
 
 build:
+  skip: True  # [py==312]
   number: 0
-  noarch: python
   entry_points:
     - lunar-find=lunarcalendar.command:find
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
+  build:
+    - patch
   host:
     - pip
-    - python >=3.7
+    - python
+    - wheel
   run:
     - ephem >=3.7.5.3
-    - python >=3.7
+    - python
     - python-dateutil >=2.6.1
     - pytz
 
@@ -47,7 +50,11 @@ about:
   home: https://github.com/KaixuYang/LunarCalendar-extension
   summary: A bugfix fork of LunarCalendar, a Lunar-Solar calendar converter.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  description: This repo forks the [LunarCalendar](https://github.com/wolfhong/LunarCalendar) repo and fixes some bugs.
+  dev_url: https://github.com/KaixuYang/LunarCalendar-extension/tree/888497987ffe7fecca94f544c03e5685f806d828
+  doc_url: https://github.com/wolfhong/LunarCalendar/blob/master/README.rst
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-add-version-var.patch
 
 build:
-  skip: True  # [py==312 or s390x or (py>39 and osx)]
+  skip: True  # [py==312 or s390x]
   number: 0
   entry_points:
     - lunar-find=lunarcalendar.command:find
@@ -28,8 +28,8 @@ requirements:
     - python
     - wheel
   run:
-    - ephem >=3.7.5.3  # [not osx]
-    - ephem >=3.7.5.3,<4.*  # [osx]
+    - ephem >=3.7.5.3  # [not arm64]
+    - ephem >=3.7.5.3,<4.*  # [arm64]
     - python
     - python-dateutil >=2.6.1
     - pytz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-add-version-var.patch
 
 build:
-  skip: True  # [py==312 or s390x]
+  skip: True  # [py==312 or s390x or (py>39 and arm64)]
   number: 0
   entry_points:
     - lunar-find=lunarcalendar.command:find

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,8 @@ requirements:
     - python
     - wheel
   run:
-    - ephem >=3.7.5.3,<4.1.*
+    - ephem >=3.7.5.3  # [not osx]
+    - ephem 3.7.5.3  # [osx]
     - python
     - python-dateutil >=2.6.1
     - pytz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-add-version-var.patch
 
 build:
-  skip: True  # [py==312 or s390x or (py>310 and osx)]
+  skip: True  # [py==312 or s390x or (py>39 and osx)]
   number: 0
   entry_points:
     - lunar-find=lunarcalendar.command:find

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ about:
   license_family: MIT
   license_file: LICENSE
   description: This repo forks the [LunarCalendar](https://github.com/wolfhong/LunarCalendar) repo and fixes some bugs.
-  dev_url: https://github.com/KaixuYang/LunarCalendar-extension/tree/888497987ffe7fecca94f544c03e5685f806d828
+  dev_url: https://github.com/KaixuYang/LunarCalendar-extension
   doc_url: https://github.com/wolfhong/LunarCalendar/blob/master/README.rst
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,8 @@ requirements:
     - python
     - wheel
   run:
-    - ephem >=3.7.5.3  # [not osx]
-    - ephem 3.7.5.3  # [osx]
+    - ephem >=3.7.5.3  # [not osx-64]
+    - ephem >=3.7.5.3,<4.*  # [osx-64]
     - python
     - python-dateutil >=2.6.1
     - pytz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,8 @@ requirements:
     - python
     - wheel
   run:
-    - ephem >=3.7.5.3  # [not osx-64]
-    - ephem >=3.7.5.3,<4.*  # [osx-64]
+    - ephem >=3.7.5.3  # [not osx]
+    - ephem >=3.7.5.3,<4.*  # [osx]
     - python
     - python-dateutil >=2.6.1
     - pytz


### PR DESCRIPTION
lunarcalendar-ext 0.0.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5207]
- dev_url:        https://github.com/KaixuYang/LunarCalendar-extension/tree/888497987ffe7fecca94f544c03e5685f806d828
- conda_forge:    https://github.com/conda-forge/lunarcalendar-ext-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/lunarcalendar-ext/0.0.1
- pypi inspector: https://inspector.pypi.io/project/lunarcalendar-ext/0.0.1

### Explanation of changes:

- new version number


[PKG-5207]: https://anaconda.atlassian.net/browse/PKG-5207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ